### PR TITLE
Fix for mzTab PSM-level FDR calculation when decoys > 0 and targets = 0

### DIFF
--- a/src/main/java/edu/ucsd/mztab/ui/MzTabFDRCleaner.java
+++ b/src/main/java/edu/ucsd/mztab/ui/MzTabFDRCleaner.java
@@ -100,12 +100,11 @@ public class MzTabFDRCleaner
 		// are not null, and there is at least one decoy
 		if (target == null || decoy == null || decoy <= 0)
 			return null;
-		// if we have non-zero decoys, but no targets (very unlikely),
-		// then we say there is one target to avoid a divide by zero error
+		// if we have non-zero decoys, but no targets (very unlikely), then FDR is 100%
 		else if (target <= 0)
-			target = 1;
+			return 1.0;
 		// global FDR = ratio of # decoys / # targets
-		return (double)decoy / (double)target;
+		else return (double)decoy / (double)target;
 	}
 	
 	public static void processMzTabFileFDR(


### PR DESCRIPTION
Previously, when an mzTab file was found to have no target PSMs and non-zero decoy PSMs (i.e. all PSMs are marked as decoys), then the code naively just set targets = 1 to avoid a divide by zero error. Obviously this would not yield a ratio as expected but simply the number of decoys in the file.

The proper fix was simply to set FDR to 1.0 in this case.