### PR TITLE
Allow "0" to be reported rather than "null" to indicate the absence of mods in the PSM section

### DIFF
--- a/src/main/java/edu/ucsd/mztab/processors/CountProcessor.java
+++ b/src/main/java/edu/ucsd/mztab/processors/CountProcessor.java
@@ -247,11 +247,17 @@ public class CountProcessor implements MzTabProcessor
 	
 	private void addElement(String type, String value) {
 		if (type == null || value == null ||
-			value.trim().equalsIgnoreCase("null") || value.trim().equals("0"))
+			value.trim().equalsIgnoreCase("null"))
 			return;
-		else if (type.equals("modifications"))
-			addModifications(value);
-		else {
+		else if (type.equals("modifications")) {
+			// section 6.3.15 of the official version 1.0.0 mzTab format specification allows
+			// a value of "0" to be used to indicate the absence of mods in the mzTab protein
+			// section; although this does not seem to be intended for the PSM section, we
+			// allow it here just to be more inclusive of otherwise valid mzTab files
+			if (value.trim().equals("0"))
+				return;
+			else addModifications(value);
+		} else {
 			Set<String> values = uniqueElements.get(type);
 			if (values == null)
 				values = new HashSet<String>();

--- a/src/main/java/edu/ucsd/mztab/processors/CountProcessor.java
+++ b/src/main/java/edu/ucsd/mztab/processors/CountProcessor.java
@@ -247,7 +247,7 @@ public class CountProcessor implements MzTabProcessor
 	
 	private void addElement(String type, String value) {
 		if (type == null || value == null ||
-			value.trim().equalsIgnoreCase("null"))
+			value.trim().equalsIgnoreCase("null") || value.trim().equals("0"))
 			return;
 		else if (type.equals("modifications"))
 			addModifications(value);

--- a/src/main/java/edu/ucsd/mztab/util/ProteomicsUtils.java
+++ b/src/main/java/edu/ucsd/mztab/util/ProteomicsUtils.java
@@ -138,7 +138,7 @@ public class ProteomicsUtils
 	}
 	
 	public static Collection<Modification> getModifications(String mods) {
-		if (mods == null || mods.equalsIgnoreCase("null"))
+		if (mods == null || mods.equalsIgnoreCase("null") || mods.equals("0"))
 			return null;
 		Collection<Modification> modifications =
 			new LinkedHashSet<Modification>();


### PR DESCRIPTION
This fix addresses an issue associated with mzTab exported by Mascot version 2.7. Since the [version 1.0.0 mzTab format specification](https://github.com/HUPO-PSI/mzTab/blob/master/specification_document-releases/1_0-Proteomics-Release/mzTab_format_specification.pdf) technically allows the value "0" to appear in protein-section "modifications" columns (see section 6.3.15 of the specification document, pages 38-39), some mzTab producers may also use this to report the absence of mods in the PSM section. This is probably incorrect but we will allow it since the meaning of "0" in this context is sufficiently clear.