### PR TITLE
Increased file mark buffer limit from 10k to 64k characters

### DIFF
--- a/src/main/java/edu/ucsd/mztab/TSVToMzTabParamGenerator.java
+++ b/src/main/java/edu/ucsd/mztab/TSVToMzTabParamGenerator.java
@@ -230,7 +230,7 @@ public class TSVToMzTabParamGenerator
 				"Reading input TSV file [%s]...", filename));
 			// read the first line of the file
 			reader = new BufferedReader(new FileReader(this.tsvFile));
-			reader.mark(10000);
+			reader.mark(65535);
 			line = reader.readLine();
 			// if the first line is not supposed to be a header line, rewind
 			if (this.hasHeader == false) {


### PR DESCRIPTION
This update increases the initial file mark read-ahead limit in TSVToMzTabParamGenerator to 65,535 characters, since that seems like a reasonable upper bound for a string buffer (2^16-1 characters), and it should catch even the most extreme cases of large TSV lines.

Background: When setting up a TSV to mzTab conversion operation, the parameter file for the conversion job is typically created in advance via a call to the TSVToMzTabParamGenerator class. This process reads the TSV file's first data row to set up some context for the conversion before entering the main loop that reads through the entire file. To do this, the code first calls the BufferedReader.mark(int readAheadLimit) method to mark the beginning of the file, then reads the first row, then calls BufferedReader.reset() to go back to the beginning of the file to be sure that the first row gets read again in the main loop.

The value of the readAheadLimit argument to BufferedReader.mark() matters, because if the first row is too long and thus exceeds this value then an exception will be thrown and the conversion will fail. Yet we don't want to set this value too high because it may cause the buffer to be reallocated to an excessively large value, which is inefficient.

When this code was first written, the value here was set to 10k characters since this seemed like a reasonable upper bound to the expected length of a single input TSV file row. However, recent cases have shown this to be too low. This update should hopefully prevent this from ever being an issue again.