### PR TITLE
Check for "decoy" column when determining a PSM row's decoy status

### DIFF
--- a/src/main/java/edu/ucsd/mztab/model/MzTabConstants.java
+++ b/src/main/java/edu/ucsd/mztab/model/MzTabConstants.java
@@ -132,6 +132,9 @@ public class MzTabConstants
 	public static final String[] KNOWN_PEPTIDE_QVALUE_COLUMNS = new String[]{
 		"PepQValue", "MS-GF:PepQValue"
 	};
+	public static final String[] KNOWN_DECOY_COLUMNS = new String[]{
+		"decoy"
+	};
 	public static final String[] KNOWN_DECOY_PATTERNS = new String[]{
 		"XXX_"
 	};

--- a/src/main/java/edu/ucsd/mztab/processors/FDRCalculationProcessor.java
+++ b/src/main/java/edu/ucsd/mztab/processors/FDRCalculationProcessor.java
@@ -300,8 +300,29 @@ public class FDRCalculationProcessor implements MzTabProcessor
 				// if the source column is present, read it
 				if (decoyColumn != null)
 					index = columns.get(decoyColumn);
-				// otherwise look at the protein accession by default
-				else index = columns.get(MzTabConstants.PSH_PROTEIN_COLUMN);
+				// otherwise look for known decoy columns
+				else {
+					// get PSM section column headers
+					List<String> headers = psmHeader.getColumns();
+					// look at each column header to see if it matches a known decoy column
+					for (String column : MzTabConstants.KNOWN_DECOY_COLUMNS) {
+						for (int i=0; i<headers.size(); i++) {
+							String header = headers.get(i);
+							if (header == null)
+								continue;
+							else if (CommonUtils.headerCorrespondsToColumn(
+								header, column, scoreColumns)) {
+								index = columns.get(header);
+								break;
+							}
+						}
+						if (index != null)
+							break;
+					}
+				}
+				// finally, look at the protein accession by default
+				if (index == null)
+					index = columns.get(MzTabConstants.PSH_PROTEIN_COLUMN);
 				// if any potential decoy-indicating
 				// column could be found, check it
 				if (index != null) {

--- a/src/main/java/edu/ucsd/mztab/processors/FDRCalculationProcessor.java
+++ b/src/main/java/edu/ucsd/mztab/processors/FDRCalculationProcessor.java
@@ -175,6 +175,24 @@ public class FDRCalculationProcessor implements MzTabProcessor
 						break;
 				}
 			}
+			// if the user did not specify a decoy-indicating column,
+			// then look for one that we know corresponds to this
+			if (decoyColumn == null) {
+				for (String column : MzTabConstants.KNOWN_DECOY_COLUMNS) {
+					for (int i=0; i<headers.size(); i++) {
+						String header = headers.get(i);
+						if (header == null)
+							continue;
+						else if (CommonUtils.headerCorrespondsToColumn(
+							header, column, scoreColumns)) {
+							decoyColumn = header;
+							break;
+						}
+					}
+					if (decoyColumn != null)
+						break;
+				}
+			}
 			// record all relevant column indices
 			for (int i=0; i<headers.size(); i++) {
 				String header = headers.get(i);
@@ -300,29 +318,8 @@ public class FDRCalculationProcessor implements MzTabProcessor
 				// if the source column is present, read it
 				if (decoyColumn != null)
 					index = columns.get(decoyColumn);
-				// otherwise look for known decoy columns
-				else {
-					// get PSM section column headers
-					List<String> headers = psmHeader.getColumns();
-					// look at each column header to see if it matches a known decoy column
-					for (String column : MzTabConstants.KNOWN_DECOY_COLUMNS) {
-						for (int i=0; i<headers.size(); i++) {
-							String header = headers.get(i);
-							if (header == null)
-								continue;
-							else if (CommonUtils.headerCorrespondsToColumn(
-								header, column, scoreColumns)) {
-								index = columns.get(header);
-								break;
-							}
-						}
-						if (index != null)
-							break;
-					}
-				}
-				// finally, look at the protein accession by default
-				if (index == null)
-					index = columns.get(MzTabConstants.PSH_PROTEIN_COLUMN);
+				// otherwise look at the protein accession by default
+				else index = columns.get(MzTabConstants.PSH_PROTEIN_COLUMN);
 				// if any potential decoy-indicating
 				// column could be found, check it
 				if (index != null) {


### PR DESCRIPTION
Added a check for column "decoy" to determine a PSM's decoy status, rather than just falling back on looking for an "XXX_" prefix in the protein accession. Some search engines mark their PSM rows as decoys directly using this column, so it's a reasonable thing to look for and doesn't cost anything if the column is not present.

Confirmed working in manual test: [this PSM row](https://massive.ucsd.edu/ProteoSAFe/result.jsp?task=3a4197b0d267423a99b4d41618c0461c&view=group_by_spectrum&file=f.MSV000080679%2Fupdates%2F2017-05-12_mwang87_9d96012e%2Fccms_result%2FmzTab%2FFilePartition_-_1_of_4_-_Bioplex_Simple_Partition_-_gene_-_HDAC11.mzXML_-_Partition_51_of_200.mzTab#%7B%22PSM_ID_lowerinput%22%3A%229736%22%2C%22PSM_ID_upperinput%22%3A%229736%22%7D) from the BioPlex dataset was not marked as decoy originally (and thus got imported into MassIVE search), even though it has a "decoy" column with value 1 (as seen in the result view). After this update, running the mzTab cleaner on this file yielded a PSM row that was identical to the previous one, except now its "opt_global_cv_MS:1002217_decoy_peptide" control column has a value of 1 rather than null.