### PR TITLE
Updated known mzTab q-value score columns

### DIFF
--- a/src/main/java/edu/ucsd/mztab/model/MzTabConstants.java
+++ b/src/main/java/edu/ucsd/mztab/model/MzTabConstants.java
@@ -127,7 +127,7 @@ public class MzTabConstants
 	
 	// constants pertaining to known optional column values
 	public static final String[] KNOWN_PSM_QVALUE_COLUMNS = new String[]{
-		"QValue", "MS-GF:QValue"
+		"QValue", "MS-GF:QValue", "percolator:Q value"
 	};
 	public static final String[] KNOWN_PEPTIDE_QVALUE_COLUMNS = new String[]{
 		"PepQValue", "MS-GF:PepQValue"


### PR DESCRIPTION
Added known PSM-level q-value column "percolator:Q value" to the list of supported q-value columns.