### PR TITLE
Minor bug fix

### DIFF
--- a/src/main/java/edu/ucsd/mztab/util/ProteomicsUtils.java
+++ b/src/main/java/edu/ucsd/mztab/util/ProteomicsUtils.java
@@ -278,7 +278,7 @@ public class ProteomicsUtils
 			return null;
 		canonicalAccession = tokens[1];
 		// if protein is a decoy, the canonical accession should also include the decoy prefix
-		if (accession.startsWith("XXX_") && canonicalAccession.startsWith("XXX_") == false)
+		if (accession.contains("XXX_") && canonicalAccession.startsWith("XXX_") == false)
 			canonicalAccession = String.format("XXX_%s", canonicalAccession);
 		return canonicalAccession;
 	}


### PR DESCRIPTION
Changed startsWith("XXX_") to contains("XXX_"), since some decoy protein identifiers (e.g. MassIVE search remapped proteins) will not strictly start with this prefix, even though they are valid decoy proteins. In all cases it should be reasonable to assume that any protein containing the string "XXX_" anywhere in its identifier is a decoy.